### PR TITLE
fix cross-spawn-async deprecated warning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
+    - nodejs_version: '10'
     - nodejs_version: '8'
     - nodejs_version: '6'
-    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install --global npm@latest

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && ava"
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "arrify": "^1.0.0",
-    "execa": "^0.1.1"
+    "execa": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -1,15 +1,15 @@
 import childProcess from 'child_process';
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test('kills a process', async t => {
-	const pid = childProcess.spawn(process.execPath).pid;
+	const {pid} = childProcess.spawn(process.execPath);
 	await m(pid, {force: true});
 
 	// Check if the process exists
 	t.throws(() => process.kill(pid));
 });
 
-test('throws on not found', t => {
-	t.throws(m('not-running.exe'));
+test('throws on not found', async t => {
+	await t.throws(m('not-running.exe'));
 });


### PR DESCRIPTION
When installing, get the warning: `npm WARN deprecated cross-spawn-async@2.2.5: cross-spawn no longer requires a build toolchain, use it instead`. This is because of the dependencies of the old `execa`.

So changes here:
1. update `execa`
2. fix style for lint error
3. add node 10 to appveyor
4. update `node >=6` as `npm@6 dropped support for node@<=4` (https://npm.community/t/compatibility-with-old-node-js-broken/2837/2) and `xo requires node >=6`