### PR TITLE
Hide the subprocess console window

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,5 +35,5 @@ module.exports = async (input, options = {}) => {
 		args.push(typeof x === 'number' ? '/pid' : '/im', x);
 	}
 
-	return execa('taskkill', args);
+	return execa('taskkill', args, {windowsHide: true});
 };


### PR DESCRIPTION
Hides the window that pops up when executing `taskkill`